### PR TITLE
Implement simple carousel for projects

### DIFF
--- a/src/app/modules/portfolio/components/projects/projects.component.html
+++ b/src/app/modules/portfolio/components/projects/projects.component.html
@@ -1,18 +1,22 @@
 <div class="container">
   <h2>Projetos Desenvolvidos</h2>
-  <ul>
-    @for (item of arrayProjects(); track item) {
-      <li>
-        <button (click)="openDialog(item)">
-          <img
-            [src]="item.src"
-            [alt]="item.alt"
-            [attr.width]="item.with"
-            [attr.height]="item.height"
-            loading="lazy"
-          >
-        </button>
-      </li>
-    }
-  </ul>
+  <div class="carousel">
+    <button class="nav prev" type="button" (click)="prev()">
+      <img src="assets/icons/chevron-up.svg" alt="Anterior">
+    </button>
+
+    <button class="image" type="button" (click)="openDialog(currentProject())">
+      <img
+        [src]="currentProject().src"
+        [alt]="currentProject().alt"
+        [attr.width]="currentProject().with"
+        [attr.height]="currentProject().height"
+        loading="lazy"
+      >
+    </button>
+
+    <button class="nav next" type="button" (click)="next()">
+      <img src="assets/icons/chevron-down.svg" alt="Próximo">
+    </button>
+  </div>
 </div>

--- a/src/app/modules/portfolio/components/projects/projects.component.scss
+++ b/src/app/modules/portfolio/components/projects/projects.component.scss
@@ -14,40 +14,53 @@
     margin: 0 0 25px 0;
   }
 
-  ul{
+  .carousel {
     display: flex;
     justify-content: center;
     align-items: center;
-    flex-wrap: wrap;
     gap: 20px;
 
-    li{
-      flex: 20%;
-      width: 160px;
-      height: 160px;
+    button {
+      background: transparent;
+      border: none;
+      cursor: pointer;
 
-      button {
-        width: 100%;
-        height: 100%;
-        cursor: pointer;
+      &.nav {
+        width: 40px;
+        height: 40px;
 
+        img {
+          width: 20px;
+          height: 20px;
+        }
+
+        &.prev img { transform: rotate(90deg); }
+        &.next img { transform: rotate(-90deg); }
+      }
+
+      &.image {
+        width: 160px;
+        height: 160px;
         background: var(--black-010);
         border: 2px solid var(--primary);
         border-radius: 7px;
         transition: 0.5s;
-        &:hover{
+
+        &:hover {
           background: var(--primary);
+        }
+
+        img {
+          width: 100%;
+          height: 100%;
         }
       }
     }
   }
 
   @media (max-width: 750px){
-    ul {
-      li {
-        flex: 100%;
-      }
+    .carousel {
+      flex-direction: column;
     }
   }
-
 }

--- a/src/app/modules/portfolio/components/projects/projects.component.ts
+++ b/src/app/modules/portfolio/components/projects/projects.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { IProjects } from '../../interface/IProjects.interface';
 import {MatDialog, MatDialogModule} from '@angular/material/dialog';
 import { EDialogPanelClass } from '../../enum/EDialogPanelClass.enum';
@@ -77,10 +77,24 @@ export class ProjectsComponent {
     }
   ])
 
+  public currentIndex = signal(0);
+
+  public currentProject = computed(() => this.arrayProjects()[this.currentIndex()]);
+
   public openDialog(data: IProjects){
     this.#dialog.open(DialogProjectsComponent, {
       data,
       panelClass: EDialogPanelClass.PROJECTS
     });
+  }
+
+  public prev(){
+    const index = this.currentIndex();
+    this.currentIndex.set(index === 0 ? this.arrayProjects().length - 1 : index - 1);
+  }
+
+  public next(){
+    const index = this.currentIndex();
+    this.currentIndex.set((index + 1) % this.arrayProjects().length);
   }
 }


### PR DESCRIPTION
## Summary
- replace grid of projects with carousel navigation
- style carousel controls and layout

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cb082450832ba1bc4bff4a9ea586